### PR TITLE
Add support for ~/.config/gittify config dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ or run `sudo make install-root` to install system-wide.
 ### Manual
 
 1. Copy _bin/gittify_ file into _~/bin/_ folder (or add it to the $PATH),
-2. Copy _homefolder/git.bashrc_ file to _$HOME/.gittify/git.bashrc_ (gittify script uses it),
+2. Copy _homefolder/git.bashrc_ file to _$HOME/.gittify/git.bashrc_ or
+   _$HOME/.config/gittify/git.bashrc (gittify script uses it),
 3. **Append** contents of _homefolder/.gitconfig_ to your _.gitconfig_ file.
   * if (your git version older than 1.7.11): use _.gitconfig.before-git-1.7.11_ instead of _.gitconfig_ file
 

--- a/bin/gittify
+++ b/bin/gittify
@@ -1,5 +1,7 @@
 if [ -f ~/.gittify/git.bashrc ]; then
   bash --rcfile ~/.gittify/git.bashrc
+elif [ -f ~/.config/gittify/git.bashrc ]; then
+  bash --rcfile ~/.config/gittify/git.bashrc
 elif [ -f /etc/gittify/git.bashrc ]; then
   bash --rcfile /etc/gittify/git.bashrc
 else


### PR DESCRIPTION
This PR adds support for `~/.config/gittify` config dir. To not introduce any breaking changes, `~/.gittify` directory is checked first.